### PR TITLE
修复日期格式不正确导致查询不到数据

### DIFF
--- a/campus-common/src/main/java/com/oddfar/campus/common/core/LambdaQueryWrapperX.java
+++ b/campus-common/src/main/java/com/oddfar/campus/common/core/LambdaQueryWrapperX.java
@@ -108,6 +108,20 @@ public class LambdaQueryWrapperX<T> extends LambdaQueryWrapper<T> {
         return betweenIfPresent(column, val1, val2);
     }
 
+    /**
+     * 格式化日期去比较
+     *
+     * @param column
+     * @param values
+     * @return
+     */
+    public LambdaQueryWrapperX<T> betweenFormatIfPresent(SFunction<T, ?> column, Map<String, Object> values) {
+
+        String val1 = (String) values.get("beginTime") + " 00:00:00";
+        String val2 = (String) values.get("endTime") + " 23:59:59";
+        return betweenIfPresent(column, val1, val2);
+    }
+
     // ========== 重写父类方法，方便链式调用 ==========
 
     @Override

--- a/campus-framework/src/main/java/com/oddfar/campus/framework/mapper/SysConfigMapper.java
+++ b/campus-framework/src/main/java/com/oddfar/campus/framework/mapper/SysConfigMapper.java
@@ -13,7 +13,7 @@ public interface SysConfigMapper extends BaseMapperX<SysConfigEntity> {
                 .likeIfPresent(SysConfigEntity::getConfigName, config.getConfigName())
                 .likeIfPresent(SysConfigEntity::getConfigKey, config.getConfigKey())
                 .eqIfPresent(SysConfigEntity::getGroupCode, config.getGroupCode())
-                .betweenIfPresent(SysConfigEntity::getCreateTime, config.getParams())
+                .betweenFormatIfPresent(SysConfigEntity::getCreateTime, config.getParams())
         );
 
     }

--- a/campus-framework/src/main/java/com/oddfar/campus/framework/mapper/SysDictDataMapper.java
+++ b/campus-framework/src/main/java/com/oddfar/campus/framework/mapper/SysDictDataMapper.java
@@ -16,7 +16,7 @@ public interface SysDictDataMapper extends BaseMapperX<SysDictDataEntity> {
                 .likeIfPresent(SysDictDataEntity::getDictType, dictData.getDictType())
                 .likeIfPresent(SysDictDataEntity::getDictLabel, dictData.getDictLabel())
                 .eqIfPresent(SysDictDataEntity::getStatus, "0")
-                .betweenIfPresent(SysDictDataEntity::getCreateTime, dictData.getParams())
+                .betweenFormatIfPresent(SysDictDataEntity::getCreateTime, dictData.getParams())
                 .orderByAsc(SysDictDataEntity::getDictSort));
     }
 

--- a/campus-framework/src/main/java/com/oddfar/campus/framework/mapper/SysDictTypeMapper.java
+++ b/campus-framework/src/main/java/com/oddfar/campus/framework/mapper/SysDictTypeMapper.java
@@ -15,7 +15,7 @@ public interface SysDictTypeMapper extends BaseMapperX<SysDictTypeEntity> {
                 .likeIfPresent(SysDictTypeEntity::getDictName, dictType.getDictName())
                 .likeIfPresent(SysDictTypeEntity::getDictType, dictType.getDictType())
                 .eqIfPresent(SysDictTypeEntity::getStatus, dictType.getStatus())
-                .betweenIfPresent(SysDictTypeEntity::getCreateTime, dictType.getParams()));
+                .betweenFormatIfPresent(SysDictTypeEntity::getCreateTime, dictType.getParams()));
     }
 
 

--- a/campus-framework/src/main/java/com/oddfar/campus/framework/mapper/SysLoginLogMapper.java
+++ b/campus-framework/src/main/java/com/oddfar/campus/framework/mapper/SysLoginLogMapper.java
@@ -19,7 +19,7 @@ public interface SysLoginLogMapper extends BaseMapperX<SysLoginLogEntity> {
                 .eqIfPresent(SysLoginLogEntity::getUserId, logininfor.getUserId())
                 .eqIfPresent(SysLoginLogEntity::getUserName,logininfor.getUserName())
                 .eqIfPresent(SysLoginLogEntity::getStatus, logininfor.getStatus())
-                .betweenIfPresent(SysLoginLogEntity::getLoginTime, logininfor.getParams())
+                .betweenFormatIfPresent(SysLoginLogEntity::getLoginTime, logininfor.getParams())
                 .orderByDesc(SysLoginLogEntity::getInfoId)
         );
     }

--- a/campus-framework/src/main/java/com/oddfar/campus/framework/mapper/SysOperLogMapper.java
+++ b/campus-framework/src/main/java/com/oddfar/campus/framework/mapper/SysOperLogMapper.java
@@ -28,7 +28,7 @@ public interface SysOperLogMapper extends BaseMapperX<SysOperLogEntity> {
                 .eqIfPresent(SysOperLogEntity::getStatus,operLog.getStatus())
                 .eqIfPresent(SysOperLogEntity::getOperIp, operLog.getOperIp())
                 .eqIfPresent(SysOperLogEntity::getOperId,operLog.getOperId())
-                .betweenIfPresent(SysOperLogEntity::getOperTime, operLog.getParams())
+                .betweenFormatIfPresent(SysOperLogEntity::getOperTime, operLog.getParams())
                 .orderByDesc(SysOperLogEntity::getOperId)
         );
     }
@@ -59,7 +59,7 @@ public interface SysOperLogMapper extends BaseMapperX<SysOperLogEntity> {
                 .likeIfPresent(SysOperLogEntity::getAppName, operLog.getAppName())
                 .likeIfPresent(SysOperLogEntity::getLogName, operLog.getLogName())
                 .eqIfPresent(SysOperLogEntity::getOperIp, operLog.getOperIp())
-                .betweenIfPresent(SysOperLogEntity::getOperTime, operLog.getParams())
+                .betweenFormatIfPresent(SysOperLogEntity::getOperTime, operLog.getParams())
         );
     }
 }

--- a/campus-framework/src/main/java/com/oddfar/campus/framework/mapper/SysResourceMapper.java
+++ b/campus-framework/src/main/java/com/oddfar/campus/framework/mapper/SysResourceMapper.java
@@ -13,7 +13,7 @@ public interface SysResourceMapper extends BaseMapperX<SysResourceEntity> {
     default PageResult<SysResourceEntity> selectPage(SysResourceEntity resource) {
 
         return selectPage(new LambdaQueryWrapperX<SysResourceEntity>()
-                .betweenIfPresent(SysResourceEntity::getCreateTime, resource.getParams()));
+                .betweenFormatIfPresent(SysResourceEntity::getCreateTime, resource.getParams()));
     }
 
 

--- a/campus-framework/src/main/java/com/oddfar/campus/framework/mapper/SysUserMapper.java
+++ b/campus-framework/src/main/java/com/oddfar/campus/framework/mapper/SysUserMapper.java
@@ -17,7 +17,7 @@ public interface SysUserMapper extends BaseMapperX<SysUserEntity> {
                 .likeIfPresent(SysUserEntity::getUserName, user.getUserName())
                 .likeIfPresent(SysUserEntity::getPhonenumber, user.getPhonenumber())
                 .eqIfPresent(SysUserEntity::getStatus, user.getStatus())
-                .betweenIfPresent(SysUserEntity::getCreateTime, user.getParams())
+                .betweenFormatIfPresent(SysUserEntity::getCreateTime, user.getParams())
         );
     }
 

--- a/campus-modular/src/main/java/com/oddfar/campus/business/mapper/ILogMapper.java
+++ b/campus-modular/src/main/java/com/oddfar/campus/business/mapper/ILogMapper.java
@@ -19,7 +19,7 @@ public interface ILogMapper extends BaseMapperX<ILog> {
         return selectPage(new LambdaQueryWrapperX<ILog>()
                 .eqIfPresent(ILog::getMobile, iLog.getMobile())
                 .eqIfPresent(ILog::getStatus, iLog.getStatus())
-                .betweenIfPresent(ILog::getOperTime, iLog.getParams())
+                .betweenFormatIfPresent(ILog::getOperTime, iLog.getParams())
                 .orderByDesc(ILog::getLogId)
         );
 
@@ -31,7 +31,7 @@ public interface ILogMapper extends BaseMapperX<ILog> {
                 .eqIfPresent(ILog::getMobile, iLog.getMobile())
                 .eqIfPresent(ILog::getStatus, iLog.getStatus())
                 .eq(ILog::getCreateUser, userId)
-                .betweenIfPresent(ILog::getOperTime, iLog.getParams())
+                .betweenFormatIfPresent(ILog::getOperTime, iLog.getParams())
                 .orderByDesc(ILog::getLogId)
         );
 

--- a/campus-modular/src/main/java/com/oddfar/campus/business/mapper/IShopMapper.java
+++ b/campus-modular/src/main/java/com/oddfar/campus/business/mapper/IShopMapper.java
@@ -26,7 +26,7 @@ public interface IShopMapper extends BaseMapperX<IShop> {
                 .likeIfPresent(IShop::getDistrictName, iShop.getDistrictName())
                 .likeIfPresent(IShop::getCityName, iShop.getCityName())
                 .likeIfPresent(IShop::getTenantName, iShop.getTenantName())
-                .betweenIfPresent(IShop::getCreateTime, iShop.getParams())
+                .betweenFormatIfPresent(IShop::getCreateTime, iShop.getParams())
         );
 
     }

--- a/campus-modular/src/main/java/com/oddfar/campus/business/mapper/IUserMapper.java
+++ b/campus-modular/src/main/java/com/oddfar/campus/business/mapper/IUserMapper.java
@@ -21,7 +21,7 @@ public interface IUserMapper extends BaseMapperX<IUser> {
                 .eqIfPresent(IUser::getUserId, iUser.getUserId())
                 .eqIfPresent(IUser::getMobile, iUser.getMobile())
                 .eqIfPresent(IUser::getProvinceName, iUser.getProvinceName())
-                .betweenIfPresent(IUser::getExpireTime, iUser.getParams())
+                .betweenFormatIfPresent(IUser::getExpireTime, iUser.getParams())
                 .orderByAsc(IUser::getCreateTime)
         );
 
@@ -34,7 +34,7 @@ public interface IUserMapper extends BaseMapperX<IUser> {
                 .eqIfPresent(IUser::getMobile, iUser.getMobile())
                 .eqIfPresent(IUser::getProvinceName, iUser.getProvinceName())
                 .eq(IUser::getCreateUser, userId)
-                .betweenIfPresent(IUser::getExpireTime, iUser.getParams())
+                .betweenFormatIfPresent(IUser::getExpireTime, iUser.getParams())
                 .orderByAsc(IUser::getCreateTime)
         );
 


### PR DESCRIPTION
时间字符串参数是yyyy-MM-dd形式，数据库数据包含HH:mm:ss 匹配不上，创建betweenFormatIfPresent方法把前端传的时间参数补上00:00:00和23:59:59