### PR TITLE
设置+8时区，避免因为时区问题导致预约时间不正确

### DIFF
--- a/campus-modular/src/main/java/com/oddfar/campus/CampusApplication.java
+++ b/campus-modular/src/main/java/com/oddfar/campus/CampusApplication.java
@@ -3,6 +3,9 @@ package com.oddfar.campus;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import java.time.ZoneOffset;
+import java.util.TimeZone;
+
 /**
  * GitHub: https://github.com/oddfar/campus-imaotai
  * @author oddfar
@@ -11,6 +14,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class CampusApplication {
 
     public static void main(String[] args) {
+        //设置+8时区，避免因为时区问题导致预约时间不正确
+        TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.of("+8")));
         SpringApplication.run(CampusApplication.class, args);
     }
 


### PR DESCRIPTION
设置+8时区，避免因为时区问题导致预约时间不正确