### PR TITLE
Update nginx.conf to fix 404 error for the CAPTCHA.

### DIFF
--- a/doc/docker/nginx/conf/nginx.conf
+++ b/doc/docker/nginx/conf/nginx.conf
@@ -12,7 +12,7 @@ http {
 
     server {
         listen       80;
-        server_name  localhost;
+        server_name  127.0.0.1;
 
         # https配置参考 start
         #listen       443 ssl;


### PR DESCRIPTION
This can fix the 404 error for the CAPTCHA in some platforms