### PR TITLE
fix:修改前端日志查询格式异常，导致无法查询具体时间日志

### DIFF
--- a/vue_campus_admin/src/views/imt/log/index.vue
+++ b/vue_campus_admin/src/views/imt/log/index.vue
@@ -35,9 +35,9 @@
       <el-form-item label="操作时间">
         <el-date-picker
           v-model="dateRange"
-          style="width: 240px"
-          value-format="yyyy-MM-dd"
-          type="daterange"
+          style="width: 340px"
+          value-format="yyyy-MM-dd HH:mm:ss"
+          type="datetimerange"
           range-separator="-"
           start-placeholder="开始日期"
           end-placeholder="结束日期"


### PR DESCRIPTION
前端查询预约日志的时候，发现日期只能精确到日，改为精确到秒则可以查询一天任意时间段日志