### PR TITLE
解决SQLITE_BUSY错误处理，SQLite 由于是文件数据库，不支持并发，最大线程数改为1，如果使用MySQL数据库，这里改为自定义数量

### DIFF
--- a/campus-common/src/main/java/com/oddfar/campus/common/core/RedisCache.java
+++ b/campus-common/src/main/java/com/oddfar/campus/common/core/RedisCache.java
@@ -179,7 +179,7 @@ public class RedisCache {
      */
     public <T> long setCacheList(final String key, final List<T> dataList) {
         if (redisDisabled) {
-            dictLocalCache.put(key, JSON.toJSONString(dataList));
+            dictLocalCache.put(key, dataList);
             return dataList.size();
         }
         Long count = redisTemplate.opsForList().rightPushAll(key, dataList);
@@ -211,8 +211,7 @@ public class RedisCache {
      */
     public <T> List<T> getCacheList(final String key) {
         if (redisDisabled) {
-            Object obj = dictLocalCache.get(key);
-            return (List<T>) obj;
+            return (List<T>) dictLocalCache.get(key);
         }
         return redisTemplate.opsForList().range(key, 0, -1);
     }

--- a/campus-modular/src/main/resources/application-dev.yml
+++ b/campus-modular/src/main/resources/application-dev.yml
@@ -35,12 +35,12 @@ spring:
         data-source-properties:
           journal_mode: WAL
           cache: shared
-        # 最大连接池数量
-        maxPoolSize: 20
+        # 最大连接池数量（解决SQLITE_BUSY错误处理，SQLite 由于是文件数据库，不支持并发，最大线程数改为1，如果使用MySQL数据库，这里改为自定义数量）
+        maxPoolSize: 1
         # 最小空闲线程数量
-        minIdle: 10
+        minIdle: 1
         # 配置获取连接等待超时的时间
-        connectionTimeout: 30000
+        connectionTimeout: 300000
         # 校验超时时间
         validationTimeout: 5000
         # 空闲连接存活最大时间，默认10分钟


### PR DESCRIPTION
解决SQLITE_BUSY错误处理，SQLite 由于是文件数据库，不支持并发，最大线程数改为1，如果使用MySQL数据库，这里改为自定义数量