### PR TITLE
fix: replace fragile App Store HTML scraping with iTunes lookup API

### DIFF
--- a/campus-modular/src/main/java/com/oddfar/campus/business/service/impl/IMTServiceImpl.java
+++ b/campus-modular/src/main/java/com/oddfar/campus/business/service/impl/IMTServiceImpl.java
@@ -39,8 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+
 import java.util.Random;
 
 @Service
@@ -85,13 +84,21 @@ public class IMTServiceImpl implements IMTService {
         if (StringUtils.isNotEmpty(mtVersion)) {
             return mtVersion;
         }
-        String url = "https://apps.apple.com/cn/app/i%E8%8C%85%E5%8F%B0/id1600482450";
-        String htmlContent = HttpUtil.get(url);
-        Pattern pattern = Pattern.compile("new__latest__version\">(.*?)</p>", Pattern.DOTALL);
-        Matcher matcher = pattern.matcher(htmlContent);
-        if (matcher.find()) {
-            mtVersion = matcher.group(1);
-            mtVersion = mtVersion.replace("版本 ", "");
+        // Use iTunes lookup API (structured JSON) instead of scraping App Store HTML
+        String url = "https://itunes.apple.com/cn/lookup?id=1600482450";
+        try {
+            String response = HttpUtil.get(url);
+            JSONObject json = JSON.parseObject(response);
+            JSONArray results = json.getJSONArray("results");
+            if (results != null && !results.isEmpty()) {
+                mtVersion = results.getJSONObject(0).getString("version");
+            }
+        } catch (Exception e) {
+            logger.error("Failed to fetch iMoutai version from Apple iTunes API", e);
+        }
+        // Fallback to a known version if API call fails
+        if (StringUtils.isEmpty(mtVersion)) {
+            mtVersion = "1.9.7";
         }
         redisCache.setCacheObject(IMTCacheConstants.MT_VERSION, mtVersion);
 


### PR DESCRIPTION
### Root Cause

The getMTVersion() method was scraping Apple's App Store HTML page using a regex pattern targeting the new__latest__version CSS class. Apple has since changed the page to a JSON-injected SPA, making the regex always fail. As a result, getMTVersion() returns null, causing the MT-APP-Version header to be sent as null in all API requests. The iMoutai server rejects this with error code 4821.

### Fix

1. Replaced HTML scraping with the official iTunes lookup API (itunes.apple.com/cn/lookup?id=1600482450), which returns structured JSON with a "version" field -- far more reliable than parsing HTML.
2. Added a fallback default version (1.9.7) in case the API call fails, preventing null from propagating to the API headers.
3. Removed unused Pattern/Matcher imports.

### Testing

- Verified the iTunes lookup API returns version 1.9.7 for this app ID
- The fix follows the same HTTP + JSON parsing patterns already used throughout the codebase (hutool HttpUtil + fastjson2)
- No new dependencies required

Fixes #394